### PR TITLE
chore: update nginx to 1.29.0

### DIFF
--- a/front/Dockerfile
+++ b/front/Dockerfile
@@ -6,7 +6,7 @@ RUN npm i
 RUN npx gulp build
 
 
-FROM nginx:1.27.2-alpine as runtime
+FROM nginx:1.29.0-alpine as runtime
 ENV WORKDIR=/srv/www
 WORKDIR $WORKDIR
 COPY nginx.conf /etc/nginx


### PR DESCRIPTION
## Summary
- use nginx:1.29.0-alpine for frontend runtime image

## Testing
- `npm test` (fails: Error: no test specified)


------
https://chatgpt.com/codex/tasks/task_e_689bd9e4d8c88325ac638e88f4b20eef